### PR TITLE
feat: Expense dashboard with category and vendor breakdowns

### DIFF
--- a/__tests__/fixtures/expenses.ts
+++ b/__tests__/fixtures/expenses.ts
@@ -1,0 +1,142 @@
+import type { ExpenseBreakdownRow } from '@/types/breakdowns';
+import type { TrendSeries } from '@/types/trends';
+
+// ---------------------------------------------------------------------------
+// Category breakdown fixtures
+// ---------------------------------------------------------------------------
+
+export const mockExpenseCategoryRows: ExpenseBreakdownRow[] = [
+  {
+    categoryId: 'cat-1',
+    categoryName: 'Software & Subscriptions',
+    expenseAmount: 12500,
+    transactionCount: 8,
+    avgTransactionAmount: 1562.5,
+  },
+  {
+    categoryId: 'cat-2',
+    categoryName: 'Payroll',
+    expenseAmount: 85000,
+    transactionCount: 2,
+    avgTransactionAmount: 42500,
+  },
+  {
+    categoryId: 'cat-3',
+    categoryName: 'Office Supplies',
+    expenseAmount: 3200,
+    transactionCount: 12,
+    avgTransactionAmount: 266.67,
+  },
+];
+
+export const mockEmptyCategoryRows: ExpenseBreakdownRow[] = [];
+
+// ---------------------------------------------------------------------------
+// Vendor breakdown fixtures
+// ---------------------------------------------------------------------------
+
+export const mockExpenseVendorRows: ExpenseBreakdownRow[] = [
+  {
+    vendorId: 'v-1',
+    vendorName: 'Acme Corp',
+    expenseAmount: 22000,
+    transactionCount: 5,
+    avgTransactionAmount: 4400,
+  },
+  {
+    vendorId: 'v-2',
+    vendorName: 'Office Depot',
+    expenseAmount: 3200,
+    transactionCount: 12,
+    avgTransactionAmount: 266.67,
+  },
+  {
+    vendorId: 'v-3',
+    vendorName: 'Gusto Payroll',
+    expenseAmount: 85000,
+    transactionCount: 2,
+    avgTransactionAmount: 42500,
+  },
+];
+
+export const mockEmptyVendorRows: ExpenseBreakdownRow[] = [];
+
+// ---------------------------------------------------------------------------
+// Raw DB rows for unit tests
+// ---------------------------------------------------------------------------
+
+export const mockExpenseFactRows = [
+  {
+    id: 'ef-1',
+    organization_id: 'org-1',
+    period_id: 'p1',
+    category_id: 'cat-1',
+    vendor_id: 'v-1',
+    expense_amount: 12500,
+    transaction_count: 8,
+  },
+  {
+    id: 'ef-2',
+    organization_id: 'org-1',
+    period_id: 'p1',
+    category_id: 'cat-2',
+    vendor_id: 'v-3',
+    expense_amount: 85000,
+    transaction_count: 2,
+  },
+  {
+    id: 'ef-3',
+    organization_id: 'org-1',
+    period_id: 'p1',
+    category_id: 'cat-3',
+    vendor_id: 'v-2',
+    expense_amount: 3200,
+    transaction_count: 12,
+  },
+];
+
+export const mockOtherOrgExpenseFactRows = [
+  {
+    id: 'ef-99',
+    organization_id: 'org-2',
+    period_id: 'p1',
+    category_id: 'cat-1',
+    vendor_id: 'v-9',
+    expense_amount: 99999,
+    transaction_count: 1,
+  },
+];
+
+export const mockCategoryDimensionRows = [
+  { id: 'cat-1', name: 'Software & Subscriptions', organization_id: 'org-1' },
+  { id: 'cat-2', name: 'Payroll', organization_id: 'org-1' },
+  { id: 'cat-3', name: 'Office Supplies', organization_id: 'org-1' },
+];
+
+export const mockVendorDimensionRows = [
+  { id: 'v-1', name: 'Acme Corp', organization_id: 'org-1' },
+  { id: 'v-2', name: 'Office Depot', organization_id: 'org-1' },
+  { id: 'v-3', name: 'Gusto Payroll', organization_id: 'org-1' },
+];
+
+// ---------------------------------------------------------------------------
+// Expense trend fixture (reuses TrendSeries shape)
+// ---------------------------------------------------------------------------
+
+export const mockExpenseTrendSeries: TrendSeries = {
+  metricName: 'total_expenses',
+  displayName: 'Total Expenses',
+  unit: 'currency',
+  dataPoints: [
+    { periodId: 'p1', label: 'Jan 2026', value: 100700, unit: 'currency' },
+    { periodId: 'p2', label: 'Feb 2026', value: 98500, unit: 'currency' },
+    { periodId: 'p3', label: 'Mar 2026', value: 105200, unit: 'currency' },
+  ],
+};
+
+export const mockEmptyExpenseTrendSeries: TrendSeries = {
+  metricName: 'total_expenses',
+  displayName: 'Total Expenses',
+  unit: 'currency',
+  dataPoints: [],
+};

--- a/app/api/kpis/breakdowns/expenses/route.test.ts
+++ b/app/api/kpis/breakdowns/expenses/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  mockExpenseCategoryRows,
+  mockExpenseVendorRows,
+  mockEmptyCategoryRows,
+} from '@/__tests__/fixtures/expenses';
+
+vi.mock('@/lib/kpi/expense-breakdowns', () => ({
+  fetchExpenseBreakdown: vi.fn(),
+}));
+
+import { fetchExpenseBreakdown } from '@/lib/kpi/expense-breakdowns';
+
+const mockedFetchExpenseBreakdown = vi.mocked(fetchExpenseBreakdown);
+
+function buildRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/kpis/breakdowns/expenses');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url.toString());
+}
+
+describe('GET /api/kpis/breakdowns/expenses', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('given valid organizationId and groupBy=category', () => {
+    it('returns 200 with a BreakdownApiResponse containing category rows', async () => {
+      mockedFetchExpenseBreakdown.mockResolvedValue(mockExpenseCategoryRows);
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        groupBy: 'category',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toHaveProperty('rows');
+      expect(body).toHaveProperty('groupBy', 'category');
+      expect(body).toHaveProperty('organizationId', 'org-1');
+      expect(body.rows).toHaveLength(3);
+    });
+  });
+
+  describe('given valid organizationId and groupBy=vendor', () => {
+    it('returns 200 with a BreakdownApiResponse containing vendor rows', async () => {
+      mockedFetchExpenseBreakdown.mockResolvedValue(mockExpenseVendorRows);
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        groupBy: 'vendor',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.groupBy).toBe('vendor');
+      expect(body.rows).toHaveLength(3);
+    });
+  });
+
+  describe('given organizationId query param is absent', () => {
+    it('returns 400 with a validation error', async () => {
+      const { GET } = await import('./route');
+      const request = buildRequest({ groupBy: 'category' });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('given groupBy query param is absent', () => {
+    it('returns 400 with a validation error', async () => {
+      const { GET } = await import('./route');
+      const request = buildRequest({ organizationId: 'org-1' });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('given an invalid groupBy value', () => {
+    it('returns 400 with a validation error', async () => {
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        groupBy: 'invalid_dimension',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('given fetchExpenseBreakdown returns an empty array', () => {
+    it('returns 200 with an empty rows array', async () => {
+      mockedFetchExpenseBreakdown.mockResolvedValue(mockEmptyCategoryRows);
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        groupBy: 'category',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.rows).toEqual([]);
+    });
+  });
+
+  describe('given fetchExpenseBreakdown throws an unexpected error', () => {
+    it('returns 500 without leaking internal error details', async () => {
+      mockedFetchExpenseBreakdown.mockRejectedValue(
+        new Error('DB connection refused: secret-host:5432')
+      );
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        groupBy: 'category',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body).toHaveProperty('error');
+      expect(body.error).not.toContain('secret-host');
+      expect(body.error).not.toContain('DB connection');
+    });
+  });
+});

--- a/app/api/kpis/breakdowns/expenses/route.ts
+++ b/app/api/kpis/breakdowns/expenses/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getClient } from '@/lib/zerodb/client';
+import { fetchExpenseBreakdown } from '@/lib/kpi/expense-breakdowns';
+import type { BreakdownApiResponse, BreakdownGroupBy } from '@/types/breakdowns';
+import type { ExpenseBreakdownRow } from '@/types/breakdowns';
+
+const VALID_GROUP_BY: BreakdownGroupBy[] = ['category', 'vendor'];
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const { searchParams } = request.nextUrl;
+
+  const organizationId = searchParams.get('organizationId');
+  const groupByParam = searchParams.get('groupBy');
+
+  if (!organizationId) {
+    return NextResponse.json(
+      { error: 'Missing required query parameter: organizationId' },
+      { status: 400 }
+    );
+  }
+
+  if (!groupByParam) {
+    return NextResponse.json(
+      { error: 'Missing required query parameter: groupBy' },
+      { status: 400 }
+    );
+  }
+
+  if (!VALID_GROUP_BY.includes(groupByParam as BreakdownGroupBy)) {
+    return NextResponse.json(
+      { error: `Invalid groupBy value. Allowed values: ${VALID_GROUP_BY.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  const groupBy = groupByParam as BreakdownGroupBy;
+  const periodType = searchParams.get('periodType') ?? 'monthly';
+  const sortBy = searchParams.get('sortBy') ?? undefined;
+  const sortOrder = (searchParams.get('sortOrder') as 'asc' | 'desc' | null) ?? undefined;
+
+  try {
+    const client = getClient();
+    const rows = await fetchExpenseBreakdown(client, {
+      organizationId,
+      groupBy,
+      periodType,
+      sortBy,
+      sortOrder,
+    });
+
+    const body: BreakdownApiResponse<ExpenseBreakdownRow> = {
+      rows,
+      groupBy,
+      organizationId,
+      periodType,
+    };
+
+    return NextResponse.json(body, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: 'An unexpected error occurred. Please try again later.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/expenses/page.test.tsx
+++ b/app/expenses/page.test.tsx
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ExpensesPage from './page';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock recharts ResponsiveContainer for test environment
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+  };
+});
+
+const validTrendResponse = {
+  trends: [
+    {
+      metricName: 'total_expenses',
+      displayName: 'Total Expenses',
+      unit: 'currency',
+      dataPoints: [
+        { periodId: 'p1', label: 'Jan 2026', value: 100700, unit: 'currency' },
+        { periodId: 'p2', label: 'Feb 2026', value: 98500, unit: 'currency' },
+      ],
+    },
+  ],
+  periodType: 'monthly',
+  organizationId: 'org-1',
+};
+
+const emptytrendResponse = {
+  trends: [
+    {
+      metricName: 'total_expenses',
+      displayName: 'Total Expenses',
+      unit: 'currency',
+      dataPoints: [],
+    },
+  ],
+  periodType: 'monthly',
+  organizationId: 'org-1',
+};
+
+const validCategoryBreakdownResponse = {
+  rows: [
+    {
+      categoryId: 'cat-1',
+      categoryName: 'Software & Subscriptions',
+      expenseAmount: 12500,
+      transactionCount: 8,
+      avgTransactionAmount: 1562.5,
+    },
+    {
+      categoryId: 'cat-2',
+      categoryName: 'Payroll',
+      expenseAmount: 85000,
+      transactionCount: 2,
+      avgTransactionAmount: 42500,
+    },
+  ],
+  groupBy: 'category',
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+const validVendorBreakdownResponse = {
+  rows: [
+    {
+      vendorId: 'v-1',
+      vendorName: 'Acme Corp',
+      expenseAmount: 22000,
+      transactionCount: 5,
+      avgTransactionAmount: 4400,
+    },
+    {
+      vendorId: 'v-2',
+      vendorName: 'Office Depot',
+      expenseAmount: 3200,
+      transactionCount: 12,
+      avgTransactionAmount: 266.67,
+    },
+  ],
+  groupBy: 'vendor',
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+const emptyBreakdownResponse = {
+  rows: [],
+  groupBy: 'category',
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+function mockBothApiCallsSuccess() {
+  mockFetch
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => validTrendResponse,
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => validCategoryBreakdownResponse,
+    });
+}
+
+describe('Expense Dashboard', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading states
+  // -------------------------------------------------------------------------
+
+  describe('given both API calls are still pending', () => {
+    it('shows a loading indicator', () => {
+      mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+
+      render(<ExpensesPage />);
+
+      expect(screen.getByTestId('expenses-loading')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Loaded states — trend
+  // -------------------------------------------------------------------------
+
+  describe('given trend data loads successfully', () => {
+    it('renders the expense trend chart section', async () => {
+      mockBothApiCallsSuccess();
+
+      render(<ExpensesPage />);
+
+      const section = await screen.findByTestId('expense-trend-section');
+      expect(section).toBeInTheDocument();
+    });
+
+    it('shows Total Expenses as the chart legend entry', async () => {
+      mockBothApiCallsSuccess();
+
+      render(<ExpensesPage />);
+
+      expect(await screen.findByText('Total Expenses')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the trend API returns empty data', () => {
+    it('shows the chart empty state', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => emptytrendResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validCategoryBreakdownResponse,
+        });
+
+      render(<ExpensesPage />);
+
+      expect(await screen.findByTestId('trend-chart-empty')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Loaded states — breakdown table (default = category)
+  // -------------------------------------------------------------------------
+
+  describe('given category breakdown data loads successfully', () => {
+    it('renders the breakdown table section', async () => {
+      mockBothApiCallsSuccess();
+
+      render(<ExpensesPage />);
+
+      const section = await screen.findByTestId('expense-breakdown-section');
+      expect(section).toBeInTheDocument();
+    });
+
+    it('renders a row for each category', async () => {
+      mockBothApiCallsSuccess();
+
+      render(<ExpensesPage />);
+
+      expect(await screen.findByText('Software & Subscriptions')).toBeInTheDocument();
+      expect(await screen.findByText('Payroll')).toBeInTheDocument();
+    });
+
+    it('displays the formatted expense amount for each category', async () => {
+      mockBothApiCallsSuccess();
+
+      render(<ExpensesPage />);
+
+      await screen.findByTestId('expense-breakdown-section');
+      // $85,000 formatted
+      expect(screen.getByText('$85,000')).toBeInTheDocument();
+    });
+  });
+
+  describe('given breakdown data is empty', () => {
+    it('shows an empty state in the breakdown section', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validTrendResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => emptyBreakdownResponse,
+        });
+
+      render(<ExpensesPage />);
+
+      expect(await screen.findByTestId('expense-breakdown-empty')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Vendor tab / filter
+  // -------------------------------------------------------------------------
+
+  describe('given the user switches to the vendor breakdown tab', () => {
+    it('fetches vendor breakdown data and renders vendor names', async () => {
+      // First render: trend + category
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validTrendResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validCategoryBreakdownResponse,
+        })
+        // After clicking vendor tab
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validVendorBreakdownResponse,
+        });
+
+      render(<ExpensesPage />);
+
+      // Wait for initial load
+      await screen.findByTestId('expense-breakdown-section');
+
+      const vendorTab = screen.getByRole('button', { name: /vendor/i });
+      await userEvent.click(vendorTab);
+
+      expect(await screen.findByText('Acme Corp')).toBeInTheDocument();
+      expect(await screen.findByText('Office Depot')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the user switches to the category breakdown tab', () => {
+    it('shows a tab button labelled Category', async () => {
+      mockBothApiCallsSuccess();
+
+      render(<ExpensesPage />);
+
+      await screen.findByTestId('expense-breakdown-section');
+
+      expect(screen.getByRole('button', { name: /category/i })).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Vendor empty state
+  // -------------------------------------------------------------------------
+
+  describe('given vendor breakdown returns no rows', () => {
+    it('shows the empty state after switching to vendor tab', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validTrendResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validCategoryBreakdownResponse,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => { return { rows: [], groupBy: 'vendor', organizationId: 'org-1', periodType: 'monthly' }; },
+        });
+
+      render(<ExpensesPage />);
+
+      await screen.findByTestId('expense-breakdown-section');
+
+      const vendorTab = screen.getByRole('button', { name: /vendor/i });
+      await userEvent.click(vendorTab);
+
+      expect(await screen.findByTestId('expense-breakdown-empty')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error states
+  // -------------------------------------------------------------------------
+
+  describe('given the trend API returns an HTTP error', () => {
+    it('shows an error state for the trend section', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validCategoryBreakdownResponse,
+        });
+
+      render(<ExpensesPage />);
+
+      expect(await screen.findByTestId('expense-trend-error')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the breakdown API returns an HTTP error', () => {
+    it('shows an error state for the breakdown section', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => validTrendResponse,
+        })
+        .mockResolvedValueOnce({ ok: false, status: 500 });
+
+      render(<ExpensesPage />);
+
+      expect(await screen.findByTestId('expense-breakdown-error')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/expenses/page.tsx
+++ b/app/expenses/page.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { TrendChart } from '@/components/charts/TrendChart';
+import { ExpenseBreakdownTable } from '@/components/tables/ExpenseBreakdownTable';
+import type { TrendSeries } from '@/types/trends';
+import type { ExpenseBreakdownRow, BreakdownApiResponse } from '@/types/breakdowns';
+
+type LoadState = 'loading' | 'loaded' | 'error';
+type BreakdownTab = 'category' | 'vendor';
+
+export default function ExpensesPage() {
+  const [trendSeries, setTrendSeries] = useState<TrendSeries[]>([]);
+  const [trendLoadState, setTrendLoadState] = useState<LoadState>('loading');
+
+  const [breakdownRows, setBreakdownRows] = useState<ExpenseBreakdownRow[]>([]);
+  const [breakdownLoadState, setBreakdownLoadState] = useState<LoadState>('loading');
+  const [activeTab, setActiveTab] = useState<BreakdownTab>('category');
+
+  const orgId = 'org-1'; // Will come from auth context post-merge with #1-#10
+
+  // Fetch expense trend on mount
+  useEffect(() => {
+    fetch(
+      `/api/kpis/trends?organizationId=${orgId}&metrics=total_expenses&periodType=monthly`
+    )
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        setTrendSeries(data.trends);
+        setTrendLoadState('loaded');
+      })
+      .catch(() => {
+        setTrendLoadState('error');
+      });
+  }, []);
+
+  // Fetch breakdown whenever the active tab changes
+  useEffect(() => {
+    setBreakdownLoadState('loading');
+    setBreakdownRows([]);
+
+    fetch(
+      `/api/kpis/breakdowns/expenses?organizationId=${orgId}&groupBy=${activeTab}&periodType=monthly`
+    )
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<BreakdownApiResponse<ExpenseBreakdownRow>>;
+      })
+      .then((data) => {
+        setBreakdownRows(data.rows);
+        setBreakdownLoadState('loaded');
+      })
+      .catch(() => {
+        setBreakdownLoadState('error');
+      });
+  }, [activeTab]);
+
+  const isInitialLoading =
+    trendLoadState === 'loading' && breakdownLoadState === 'loading';
+
+  return (
+    <div>
+      <h1>Expense Dashboard</h1>
+
+      {isInitialLoading && (
+        <div data-testid="expenses-loading">
+          <p>Loading expense data...</p>
+        </div>
+      )}
+
+      {/* Trend section */}
+      {trendLoadState === 'error' && (
+        <div data-testid="expense-trend-error">
+          <p>Failed to load expense trend data. Please try again.</p>
+        </div>
+      )}
+
+      {trendLoadState === 'loaded' && (
+        <section data-testid="expense-trend-section">
+          <h2>Expense Trend</h2>
+          <TrendChart series={trendSeries} />
+        </section>
+      )}
+
+      {/* Breakdown section */}
+      {breakdownLoadState === 'error' && (
+        <div data-testid="expense-breakdown-error">
+          <p>Failed to load expense breakdown data. Please try again.</p>
+        </div>
+      )}
+
+      {(breakdownLoadState === 'loaded' || breakdownLoadState === 'loading') &&
+        trendLoadState !== 'loading' && (
+          <section data-testid="expense-breakdown-section">
+            <h2>Expense Breakdown</h2>
+
+            <div role="group" aria-label="breakdown tabs">
+              <button
+                type="button"
+                aria-pressed={activeTab === 'category'}
+                onClick={() => setActiveTab('category')}
+              >
+                Category
+              </button>
+              <button
+                type="button"
+                aria-pressed={activeTab === 'vendor'}
+                onClick={() => setActiveTab('vendor')}
+              >
+                Vendor
+              </button>
+            </div>
+
+            {breakdownLoadState === 'loaded' && breakdownRows.length === 0 && (
+              <div data-testid="expense-breakdown-empty">
+                <p>No expense data available for this period.</p>
+              </div>
+            )}
+
+            {breakdownLoadState === 'loaded' && breakdownRows.length > 0 && (
+              <ExpenseBreakdownTable rows={breakdownRows} groupBy={activeTab} />
+            )}
+          </section>
+        )}
+    </div>
+  );
+}

--- a/components/tables/ExpenseBreakdownTable.tsx
+++ b/components/tables/ExpenseBreakdownTable.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { ExpenseBreakdownRow } from '@/types/breakdowns';
+
+interface ExpenseBreakdownTableProps {
+  rows: ExpenseBreakdownRow[];
+  groupBy: 'category' | 'vendor';
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function ExpenseBreakdownTable({ rows, groupBy }: ExpenseBreakdownTableProps) {
+  const nameKey = groupBy === 'vendor' ? 'vendorName' : 'categoryName';
+  const nameLabel = groupBy === 'vendor' ? 'Vendor' : 'Category';
+
+  return (
+    <table data-testid="expense-breakdown-table">
+      <thead>
+        <tr>
+          <th scope="col">{nameLabel}</th>
+          <th scope="col">Expense Amount</th>
+          <th scope="col">Transactions</th>
+          <th scope="col">Avg Transaction</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => {
+          const name = (row as Record<string, unknown>)[nameKey] as string | undefined;
+          const id =
+            groupBy === 'vendor'
+              ? row.vendorId ?? String(index)
+              : row.categoryId ?? String(index);
+
+          return (
+            <tr key={id} data-testid="expense-breakdown-row">
+              <td>{name ?? id}</td>
+              <td>{formatCurrency(row.expenseAmount)}</td>
+              <td>{row.transactionCount}</td>
+              <td>
+                {row.avgTransactionAmount !== null && row.avgTransactionAmount !== undefined
+                  ? formatCurrency(row.avgTransactionAmount)
+                  : '—'}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/lib/kpi/expense-breakdowns.test.ts
+++ b/lib/kpi/expense-breakdowns.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchExpenseBreakdown } from './expense-breakdowns';
+import type { ZeroDBClient } from '@/lib/zerodb/client';
+import type { BreakdownApiRequest } from '@/types/breakdowns';
+import {
+  mockExpenseFactRows,
+  mockOtherOrgExpenseFactRows,
+  mockCategoryDimensionRows,
+  mockVendorDimensionRows,
+} from '@/__tests__/fixtures/expenses';
+
+function createMockClient(overrides?: {
+  factRows?: typeof mockExpenseFactRows;
+  categoryRows?: typeof mockCategoryDimensionRows;
+  vendorRows?: typeof mockVendorDimensionRows;
+}): ZeroDBClient {
+  const factRows = overrides?.factRows ?? mockExpenseFactRows;
+  const categoryRows = overrides?.categoryRows ?? mockCategoryDimensionRows;
+  const vendorRows = overrides?.vendorRows ?? mockVendorDimensionRows;
+
+  return {
+    query: vi.fn(async (table: string, filters: Record<string, unknown>) => {
+      if (table === 'fact_expense_breakdown') {
+        const orgId = filters.organization_id;
+        const rows = factRows.filter((r) => r.organization_id === orgId);
+        return { rows };
+      }
+      if (table === 'dimension_categories') {
+        const orgId = filters.organization_id;
+        return { rows: categoryRows.filter((r) => r.organization_id === orgId) };
+      }
+      if (table === 'dimension_vendors') {
+        const orgId = filters.organization_id;
+        return { rows: vendorRows.filter((r) => r.organization_id === orgId) };
+      }
+      return { rows: [] };
+    }),
+  };
+}
+
+describe('fetchExpenseBreakdown', () => {
+  describe('given groupBy=category with data present', () => {
+    it('returns ExpenseBreakdownRows aggregated by category with names resolved', async () => {
+      const client = createMockClient();
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'category',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toHaveLength(3);
+      const software = result.find((r) => r.categoryName === 'Software & Subscriptions');
+      expect(software).toBeDefined();
+      expect(software!.expenseAmount).toBe(12500);
+      expect(software!.transactionCount).toBe(8);
+    });
+  });
+
+  describe('given groupBy=vendor with data present', () => {
+    it('returns ExpenseBreakdownRows aggregated by vendor with names resolved', async () => {
+      const client = createMockClient();
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'vendor',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toHaveLength(3);
+      const gusto = result.find((r) => r.vendorName === 'Gusto Payroll');
+      expect(gusto).toBeDefined();
+      expect(gusto!.expenseAmount).toBe(85000);
+      expect(gusto!.transactionCount).toBe(2);
+    });
+  });
+
+  describe('given groupBy=category and no expense records exist', () => {
+    it('returns an empty array', async () => {
+      const client = createMockClient({ factRows: [] });
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'category',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('given groupBy=vendor and no expense records exist', () => {
+    it('returns an empty array', async () => {
+      const client = createMockClient({ factRows: [] });
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'vendor',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('given data exists for multiple organizations', () => {
+    it('returns only rows for the specified organizationId', async () => {
+      const allRows = [...mockExpenseFactRows, ...mockOtherOrgExpenseFactRows];
+      const client = createMockClient({ factRows: allRows });
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'category',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toHaveLength(3);
+      result.forEach((r) => {
+        expect(r.expenseAmount).not.toBe(99999);
+      });
+    });
+  });
+
+  describe('given a vendor row whose name cannot be resolved in dimension_vendors', () => {
+    it('falls back to the raw vendor id as the vendorName', async () => {
+      const factRowsWithUnknownVendor = [
+        {
+          id: 'ef-new',
+          organization_id: 'org-1',
+          period_id: 'p1',
+          category_id: 'cat-1',
+          vendor_id: 'v-unknown',
+          expense_amount: 500,
+          transaction_count: 1,
+        },
+      ];
+      const client = createMockClient({ factRows: factRowsWithUnknownVendor });
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'vendor',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].vendorId).toBe('v-unknown');
+      expect(result[0].vendorName).toBe('v-unknown');
+    });
+  });
+
+  describe('given a category row whose name cannot be resolved in dimension_categories', () => {
+    it('falls back to the raw category id as the categoryName', async () => {
+      const factRowsWithUnknownCategory = [
+        {
+          id: 'ef-new',
+          organization_id: 'org-1',
+          period_id: 'p1',
+          category_id: 'cat-unknown',
+          vendor_id: 'v-1',
+          expense_amount: 500,
+          transaction_count: 1,
+        },
+      ];
+      const client = createMockClient({ factRows: factRowsWithUnknownCategory });
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'category',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].categoryId).toBe('cat-unknown');
+      expect(result[0].categoryName).toBe('cat-unknown');
+    });
+  });
+
+  describe('given sortBy=expenseAmount with sortOrder=desc', () => {
+    it('returns rows sorted by expenseAmount descending', async () => {
+      const client = createMockClient();
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'category',
+        sortBy: 'expenseAmount',
+        sortOrder: 'desc',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      expect(result[0].expenseAmount).toBeGreaterThanOrEqual(result[1].expenseAmount);
+      expect(result[1].expenseAmount).toBeGreaterThanOrEqual(result[2].expenseAmount);
+    });
+  });
+
+  describe('given avgTransactionAmount calculation', () => {
+    it('computes avgTransactionAmount as expenseAmount divided by transactionCount', async () => {
+      const client = createMockClient();
+      const request: BreakdownApiRequest = {
+        organizationId: 'org-1',
+        groupBy: 'category',
+        periodType: 'monthly',
+      };
+
+      const result = await fetchExpenseBreakdown(client, request);
+
+      const software = result.find((r) => r.categoryName === 'Software & Subscriptions');
+      expect(software!.avgTransactionAmount).toBeCloseTo(1562.5, 1);
+    });
+  });
+});

--- a/lib/kpi/expense-breakdowns.ts
+++ b/lib/kpi/expense-breakdowns.ts
@@ -1,0 +1,130 @@
+import type { ZeroDBClient } from '@/lib/zerodb/client';
+import type { ExpenseBreakdownRow, BreakdownApiRequest } from '@/types/breakdowns';
+
+interface ExpenseFactRow {
+  id: string;
+  organization_id: string;
+  period_id: string;
+  category_id: string;
+  vendor_id: string;
+  expense_amount: number;
+  transaction_count: number;
+}
+
+interface CategoryDimensionRow {
+  id: string;
+  name: string;
+  organization_id: string;
+}
+
+interface VendorDimensionRow {
+  id: string;
+  name: string;
+  organization_id: string;
+}
+
+export async function fetchExpenseBreakdown(
+  client: ZeroDBClient,
+  request: BreakdownApiRequest
+): Promise<ExpenseBreakdownRow[]> {
+  const { organizationId, groupBy, sortBy, sortOrder } = request;
+
+  const [factResult, categoryResult, vendorResult] = await Promise.all([
+    client.query<ExpenseFactRow>('fact_expense_breakdown', {
+      organization_id: organizationId,
+    }),
+    client.query<CategoryDimensionRow>('dimension_categories', {
+      organization_id: organizationId,
+    }),
+    client.query<VendorDimensionRow>('dimension_vendors', {
+      organization_id: organizationId,
+    }),
+  ]);
+
+  const categoryMap = new Map<string, string>();
+  for (const cat of categoryResult.rows) {
+    categoryMap.set(cat.id, cat.name);
+  }
+
+  const vendorMap = new Map<string, string>();
+  for (const vendor of vendorResult.rows) {
+    vendorMap.set(vendor.id, vendor.name);
+  }
+
+  if (groupBy === 'category') {
+    // Aggregate by category_id
+    const grouped = new Map<string, { expenseAmount: number; transactionCount: number }>();
+
+    for (const row of factResult.rows) {
+      const key = row.category_id;
+      const existing = grouped.get(key) ?? { expenseAmount: 0, transactionCount: 0 };
+      existing.expenseAmount += row.expense_amount;
+      existing.transactionCount += row.transaction_count;
+      grouped.set(key, existing);
+    }
+
+    const rows: ExpenseBreakdownRow[] = Array.from(grouped.entries()).map(
+      ([categoryId, agg]) => ({
+        categoryId,
+        categoryName: categoryMap.get(categoryId) ?? categoryId,
+        expenseAmount: agg.expenseAmount,
+        transactionCount: agg.transactionCount,
+        avgTransactionAmount:
+          agg.transactionCount > 0 ? agg.expenseAmount / agg.transactionCount : null,
+      })
+    );
+
+    return applySorting(rows, sortBy, sortOrder);
+  }
+
+  if (groupBy === 'vendor') {
+    // Aggregate by vendor_id
+    const grouped = new Map<string, { expenseAmount: number; transactionCount: number }>();
+
+    for (const row of factResult.rows) {
+      const key = row.vendor_id;
+      const existing = grouped.get(key) ?? { expenseAmount: 0, transactionCount: 0 };
+      existing.expenseAmount += row.expense_amount;
+      existing.transactionCount += row.transaction_count;
+      grouped.set(key, existing);
+    }
+
+    const rows: ExpenseBreakdownRow[] = Array.from(grouped.entries()).map(
+      ([vendorId, agg]) => ({
+        vendorId,
+        vendorName: vendorMap.get(vendorId) ?? vendorId,
+        expenseAmount: agg.expenseAmount,
+        transactionCount: agg.transactionCount,
+        avgTransactionAmount:
+          agg.transactionCount > 0 ? agg.expenseAmount / agg.transactionCount : null,
+      })
+    );
+
+    return applySorting(rows, sortBy, sortOrder);
+  }
+
+  return [];
+}
+
+function applySorting(
+  rows: ExpenseBreakdownRow[],
+  sortBy?: string,
+  sortOrder?: 'asc' | 'desc'
+): ExpenseBreakdownRow[] {
+  if (!sortBy) return rows;
+
+  const direction = sortOrder === 'asc' ? 1 : -1;
+
+  return [...rows].sort((a, b) => {
+    const aVal = (a as Record<string, unknown>)[sortBy];
+    const bVal = (b as Record<string, unknown>)[sortBy];
+
+    if (typeof aVal === 'number' && typeof bVal === 'number') {
+      return (aVal - bVal) * direction;
+    }
+    if (typeof aVal === 'string' && typeof bVal === 'string') {
+      return aVal.localeCompare(bVal) * direction;
+    }
+    return 0;
+  });
+}

--- a/types/breakdowns.ts
+++ b/types/breakdowns.ts
@@ -1,0 +1,58 @@
+export interface RevenueBreakdownRow {
+  customerId?: string;
+  customerName?: string;
+  productId?: string;
+  productName?: string;
+  categoryId?: string;
+  categoryName?: string;
+  revenueAmount: number;
+  invoiceCount: number;
+  avgInvoiceValue: number | null;
+  paymentCollectedAmount: number;
+}
+
+export interface ExpenseBreakdownRow {
+  vendorId?: string;
+  vendorName?: string;
+  categoryId?: string;
+  categoryName?: string;
+  accountId?: string;
+  accountName?: string;
+  expenseAmount: number;
+  transactionCount: number;
+  avgTransactionAmount: number | null;
+}
+
+export interface ArApBreakdownRow {
+  balanceType: 'ar' | 'ap';
+  customerId?: string;
+  customerName?: string;
+  vendorId?: string;
+  vendorName?: string;
+  currentBucket: number;
+  bucket1_30: number;
+  bucket31_60: number;
+  bucket61_90: number;
+  bucket90Plus: number;
+  totalBalance: number;
+  overdueBalance: number;
+}
+
+export type BreakdownGroupBy = 'customer' | 'vendor' | 'category' | 'product' | 'account';
+
+export interface BreakdownApiRequest {
+  organizationId: string;
+  periodId?: string;
+  periodType?: string;
+  groupBy: BreakdownGroupBy;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+  limit?: number;
+}
+
+export interface BreakdownApiResponse<T> {
+  rows: T[];
+  groupBy: string;
+  organizationId: string;
+  periodType: string;
+}


### PR DESCRIPTION
## Summary
- Expense trend chart reusing TrendChart (total_expenses metric)
- Expense breakdown by category and vendor with tab switching
- GET /api/kpis/breakdowns/expenses with groupBy validation

## Test Plan
- 28 BDD-style tests
- `npm test` passes all tests

Closes #15, Closes #16, Closes #17

Built by AINative Dev Team