### PR TITLE
feat: Cash flow dashboard with summary cards

### DIFF
--- a/__tests__/fixtures/summary.ts
+++ b/__tests__/fixtures/summary.ts
@@ -1,0 +1,161 @@
+import type { SummaryCard } from '@/types/summary';
+
+export const mockCashOnHandCard: SummaryCard = {
+  metricName: 'cash_on_hand',
+  displayName: 'Cash on Hand',
+  value: 250000,
+  unit: 'currency',
+  delta: {
+    absoluteDelta: 15000,
+    percentDelta: 6.38,
+    comparisonType: 'prior_period',
+  },
+};
+
+export const mockRunwayCard: SummaryCard = {
+  metricName: 'runway_months',
+  displayName: 'Runway',
+  value: 14,
+  unit: 'months',
+  delta: {
+    absoluteDelta: -2,
+    percentDelta: -12.5,
+    comparisonType: 'prior_period',
+  },
+};
+
+export const mockNetCashFlowCard: SummaryCard = {
+  metricName: 'net_cash_flow',
+  displayName: 'Net Cash Flow',
+  value: 32000,
+  unit: 'currency',
+};
+
+export const mockArBalanceCard: SummaryCard = {
+  metricName: 'ar_balance',
+  displayName: 'AR Balance',
+  value: 87500,
+  unit: 'currency',
+  delta: {
+    absoluteDelta: -5000,
+    percentDelta: -5.41,
+    comparisonType: 'prior_period',
+  },
+};
+
+export const mockApBalanceCard: SummaryCard = {
+  metricName: 'ap_balance',
+  displayName: 'AP Balance',
+  value: 43200,
+  unit: 'currency',
+  delta: {
+    absoluteDelta: 3200,
+    percentDelta: 8.0,
+    comparisonType: 'prior_period',
+  },
+};
+
+export const mockSummaryMetricRows = [
+  {
+    id: 'fm1',
+    organization_id: 'org-1',
+    period_id: 'p3',
+    metric_name: 'cash_on_hand',
+    metric_value: 250000,
+    metric_unit: 'currency',
+  },
+  {
+    id: 'fm2',
+    organization_id: 'org-1',
+    period_id: 'p3',
+    metric_name: 'runway_months',
+    metric_value: 14,
+    metric_unit: 'months',
+  },
+  {
+    id: 'fm3',
+    organization_id: 'org-1',
+    period_id: 'p3',
+    metric_name: 'net_cash_flow',
+    metric_value: 32000,
+    metric_unit: 'currency',
+  },
+  {
+    id: 'fm4',
+    organization_id: 'org-1',
+    period_id: 'p3',
+    metric_name: 'ar_balance',
+    metric_value: 87500,
+    metric_unit: 'currency',
+  },
+  {
+    id: 'fm5',
+    organization_id: 'org-1',
+    period_id: 'p3',
+    metric_name: 'ap_balance',
+    metric_value: 43200,
+    metric_unit: 'currency',
+  },
+];
+
+export const mockOtherOrgMetricRows = [
+  {
+    id: 'fm6',
+    organization_id: 'org-2',
+    period_id: 'p3',
+    metric_name: 'cash_on_hand',
+    metric_value: 999999,
+    metric_unit: 'currency',
+  },
+];
+
+export const mockComparisonRows = [
+  {
+    id: 'cmp1',
+    organization_id: 'org-1',
+    metric_name: 'cash_on_hand',
+    current_period_id: 'p3',
+    comparison_period_id: 'p2',
+    current_value: 250000,
+    comparison_value: 235000,
+    absolute_delta: 15000,
+    percent_delta: 6.38,
+    comparison_type: 'prior_period',
+  },
+  {
+    id: 'cmp2',
+    organization_id: 'org-1',
+    metric_name: 'runway_months',
+    current_period_id: 'p3',
+    comparison_period_id: 'p2',
+    current_value: 14,
+    comparison_value: 16,
+    absolute_delta: -2,
+    percent_delta: -12.5,
+    comparison_type: 'prior_period',
+  },
+  {
+    id: 'cmp3',
+    organization_id: 'org-1',
+    metric_name: 'ar_balance',
+    current_period_id: 'p3',
+    comparison_period_id: 'p2',
+    current_value: 87500,
+    comparison_value: 92500,
+    absolute_delta: -5000,
+    percent_delta: -5.41,
+    comparison_type: 'prior_period',
+  },
+  {
+    id: 'cmp4',
+    organization_id: 'org-1',
+    metric_name: 'ap_balance',
+    current_period_id: 'p3',
+    comparison_period_id: 'p2',
+    current_value: 43200,
+    comparison_value: 40000,
+    absolute_delta: 3200,
+    percent_delta: 8.0,
+    comparison_type: 'prior_period',
+  },
+];

--- a/app/api/kpis/summary/route.test.ts
+++ b/app/api/kpis/summary/route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import {
+  mockCashOnHandCard,
+  mockRunwayCard,
+  mockArBalanceCard,
+  mockApBalanceCard,
+} from '@/__tests__/fixtures/summary';
+
+vi.mock('@/lib/kpi/summary', () => ({
+  fetchSummaryCards: vi.fn(),
+}));
+
+import { fetchSummaryCards } from '@/lib/kpi/summary';
+
+const mockedFetchSummaryCards = vi.mocked(fetchSummaryCards);
+
+function buildRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/kpis/summary');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url.toString());
+}
+
+describe('GET /api/kpis/summary', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('given valid organizationId and metrics params', () => {
+    it('returns 200 with a SummaryApiResponse shape', async () => {
+      mockedFetchSummaryCards.mockResolvedValue([mockCashOnHandCard, mockRunwayCard]);
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        metrics: 'cash_on_hand,runway_months',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toHaveProperty('cards');
+      expect(body).toHaveProperty('organizationId');
+      expect(body).toHaveProperty('periodType');
+      expect(body.organizationId).toBe('org-1');
+      expect(body.cards).toHaveLength(2);
+    });
+  });
+
+  describe('given includeComparison param is present', () => {
+    it('passes includeComparison=true to fetchSummaryCards', async () => {
+      mockedFetchSummaryCards.mockResolvedValue([mockArBalanceCard, mockApBalanceCard]);
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        metrics: 'ar_balance,ap_balance',
+        includeComparison: 'true',
+      });
+
+      await GET(request);
+
+      expect(mockedFetchSummaryCards).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ includeComparison: true })
+      );
+    });
+  });
+
+  describe('given organizationId query param is absent', () => {
+    it('returns 400 with a validation error message', async () => {
+      const { GET } = await import('./route');
+      const request = buildRequest({ metrics: 'cash_on_hand' });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('given metrics query param is absent', () => {
+    it('returns 400 with a validation error message', async () => {
+      const { GET } = await import('./route');
+      const request = buildRequest({ organizationId: 'org-1' });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+  });
+
+  describe('given fetchSummaryCards returns an empty array', () => {
+    it('returns 200 with an empty cards array', async () => {
+      mockedFetchSummaryCards.mockResolvedValue([]);
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        metrics: 'cash_on_hand',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.cards).toEqual([]);
+    });
+  });
+
+  describe('given fetchSummaryCards throws an unexpected error', () => {
+    it('returns 500 without leaking internal error details', async () => {
+      mockedFetchSummaryCards.mockRejectedValue(
+        new Error('DB connection refused: secret-host:5432')
+      );
+
+      const { GET } = await import('./route');
+      const request = buildRequest({
+        organizationId: 'org-1',
+        metrics: 'cash_on_hand',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body).toHaveProperty('error');
+      expect(body.error).not.toContain('secret-host');
+      expect(body.error).not.toContain('DB connection');
+    });
+  });
+});

--- a/app/api/kpis/summary/route.ts
+++ b/app/api/kpis/summary/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getClient } from '@/lib/zerodb/client';
+import { fetchSummaryCards } from '@/lib/kpi/summary';
+import type { SummaryApiResponse } from '@/types/summary';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const { searchParams } = request.nextUrl;
+
+  const organizationId = searchParams.get('organizationId');
+  const metricsParam = searchParams.get('metrics');
+
+  if (!organizationId) {
+    return NextResponse.json(
+      { error: 'Missing required query parameter: organizationId' },
+      { status: 400 }
+    );
+  }
+
+  if (!metricsParam) {
+    return NextResponse.json(
+      { error: 'Missing required query parameter: metrics' },
+      { status: 400 }
+    );
+  }
+
+  const metricNames = metricsParam
+    .split(',')
+    .map((m) => m.trim())
+    .filter(Boolean);
+  const periodType = searchParams.get('periodType') ?? 'monthly';
+  const includeComparison = searchParams.get('includeComparison') === 'true';
+
+  try {
+    const client = getClient();
+    const cards = await fetchSummaryCards(client, {
+      organizationId,
+      metricNames,
+      periodType,
+      includeComparison,
+    });
+
+    const body: SummaryApiResponse = {
+      cards,
+      organizationId,
+      periodType,
+    };
+
+    return NextResponse.json(body, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: 'An unexpected error occurred. Please try again later.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/cashflow/page.test.tsx
+++ b/app/cashflow/page.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 800, height: 400 }}>{children}</div>
+    ),
+  };
+});
+
+import CashFlowPage from './page';
+
+const validTrendsResponse = {
+  trends: [
+    {
+      metricName: 'net_cash_flow',
+      displayName: 'Net Cash Flow',
+      unit: 'currency',
+      dataPoints: [
+        { periodId: 'p1', label: 'Jan 2026', value: 28000, unit: 'currency' },
+        { periodId: 'p2', label: 'Feb 2026', value: 32000, unit: 'currency' },
+      ],
+    },
+    {
+      metricName: 'cash_inflow',
+      displayName: 'Cash Inflow',
+      unit: 'currency',
+      dataPoints: [
+        { periodId: 'p1', label: 'Jan 2026', value: 120000, unit: 'currency' },
+        { periodId: 'p2', label: 'Feb 2026', value: 135000, unit: 'currency' },
+      ],
+    },
+    {
+      metricName: 'cash_outflow',
+      displayName: 'Cash Outflow',
+      unit: 'currency',
+      dataPoints: [
+        { periodId: 'p1', label: 'Jan 2026', value: 92000, unit: 'currency' },
+        { periodId: 'p2', label: 'Feb 2026', value: 103000, unit: 'currency' },
+      ],
+    },
+  ],
+  periodType: 'monthly',
+  organizationId: 'org-1',
+};
+
+const validSummaryResponse = {
+  cards: [
+    {
+      metricName: 'cash_on_hand',
+      displayName: 'Cash on Hand',
+      value: 250000,
+      unit: 'currency',
+      delta: { absoluteDelta: 15000, percentDelta: 6.38, comparisonType: 'prior_period' },
+    },
+    {
+      metricName: 'runway_months',
+      displayName: 'Runway',
+      value: 14,
+      unit: 'months',
+      delta: { absoluteDelta: -2, percentDelta: -12.5, comparisonType: 'prior_period' },
+    },
+  ],
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+const emptySummaryResponse = {
+  cards: [],
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+describe('Cash Flow Page', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('given all data loads successfully', () => {
+    it('renders the Cash Flow page heading', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      const heading = await screen.findByRole('heading', { name: /cash flow/i });
+      expect(heading).toBeInTheDocument();
+    });
+
+    it('renders the trend chart section', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      const section = await screen.findByTestId('cashflow-trends-section');
+      expect(section).toBeInTheDocument();
+    });
+
+    it('renders the net cash flow trend series label', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      expect(await screen.findByText('Net Cash Flow')).toBeInTheDocument();
+    });
+
+    it('renders cash on hand summary card', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      expect(await screen.findByText('Cash on Hand')).toBeInTheDocument();
+    });
+
+    it('renders runway summary card', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      expect(await screen.findByText('Runway')).toBeInTheDocument();
+    });
+
+    it('renders the summary cards section', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      const section = await screen.findByTestId('cashflow-summary-section');
+      expect(section).toBeInTheDocument();
+    });
+  });
+
+  describe('given data is still loading', () => {
+    it('shows a loading indicator', () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(<CashFlowPage />);
+
+      expect(screen.getByTestId('cashflow-loading')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the trends API returns an error', () => {
+    it('shows an error state', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: true, json: async () => validSummaryResponse });
+
+      render(<CashFlowPage />);
+
+      expect(await screen.findByTestId('cashflow-error')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the summary API returns an empty cards array', () => {
+    it('renders the summary section with fallback state', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => validTrendsResponse })
+        .mockResolvedValueOnce({ ok: true, json: async () => emptySummaryResponse });
+
+      render(<CashFlowPage />);
+
+      expect(await screen.findByTestId('cashflow-summary-empty')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/cashflow/page.tsx
+++ b/app/cashflow/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { TrendChart } from '@/components/charts/TrendChart';
+import { SummaryCard } from '@/components/kpi-cards/SummaryCard';
+import type { TrendSeries } from '@/types/trends';
+import type { SummaryCard as SummaryCardData } from '@/types/summary';
+
+type LoadState = 'loading' | 'loaded' | 'error';
+
+const ORG_ID = 'org-1';
+const TREND_METRICS = 'net_cash_flow,cash_inflow,cash_outflow';
+const SUMMARY_METRICS = 'cash_on_hand,runway_months';
+
+export default function CashFlowPage() {
+  const [trends, setTrends] = useState<TrendSeries[]>([]);
+  const [cards, setCards] = useState<SummaryCardData[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+
+  useEffect(() => {
+    const trendsUrl = `/api/kpis/trends?organizationId=${ORG_ID}&metrics=${TREND_METRICS}&periodType=monthly`;
+    const summaryUrl = `/api/kpis/summary?organizationId=${ORG_ID}&metrics=${SUMMARY_METRICS}&periodType=monthly&includeComparison=true`;
+
+    Promise.all([
+      fetch(trendsUrl).then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      }),
+      fetch(summaryUrl).then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      }),
+    ])
+      .then(([trendsData, summaryData]) => {
+        setTrends(trendsData.trends);
+        setCards(summaryData.cards);
+        setLoadState('loaded');
+      })
+      .catch(() => {
+        setLoadState('error');
+      });
+  }, []);
+
+  return (
+    <div>
+      <h1>Cash Flow</h1>
+
+      {loadState === 'loading' && (
+        <div data-testid="cashflow-loading">
+          <p>Loading cash flow data...</p>
+        </div>
+      )}
+
+      {loadState === 'error' && (
+        <div data-testid="cashflow-error">
+          <p>Failed to load cash flow data. Please try again.</p>
+        </div>
+      )}
+
+      {loadState === 'loaded' && (
+        <>
+          <section data-testid="cashflow-trends-section">
+            <h2>Cash Flow Over Time</h2>
+            <TrendChart series={trends} />
+          </section>
+
+          <section data-testid="cashflow-summary-section">
+            <h2>Key Metrics</h2>
+            {cards.length === 0 ? (
+              <div data-testid="cashflow-summary-empty">
+                <p>No summary data available.</p>
+              </div>
+            ) : (
+              <div>
+                {cards.map((card) => (
+                  <SummaryCard key={card.metricName} card={card} />
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/kpi-cards/SummaryCard.test.tsx
+++ b/components/kpi-cards/SummaryCard.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { SummaryCard } from './SummaryCard';
+import type { SummaryCard as SummaryCardData } from '@/types/summary';
+
+const baseCard: SummaryCardData = {
+  metricName: 'cash_on_hand',
+  displayName: 'Cash on Hand',
+  value: 250000,
+  unit: 'currency',
+};
+
+const cardWithPositiveDelta: SummaryCardData = {
+  ...baseCard,
+  delta: {
+    absoluteDelta: 15000,
+    percentDelta: 6.38,
+    comparisonType: 'prior_period',
+  },
+};
+
+const cardWithNegativeDelta: SummaryCardData = {
+  ...baseCard,
+  delta: {
+    absoluteDelta: -2000,
+    percentDelta: -0.8,
+    comparisonType: 'prior_period',
+  },
+};
+
+const cardWithZeroDelta: SummaryCardData = {
+  ...baseCard,
+  delta: {
+    absoluteDelta: 0,
+    percentDelta: 0,
+    comparisonType: 'prior_period',
+  },
+};
+
+const runwayCard: SummaryCardData = {
+  metricName: 'runway_months',
+  displayName: 'Runway',
+  value: 14,
+  unit: 'months',
+};
+
+describe('SummaryCard', () => {
+  describe('given a card with a currency value', () => {
+    it('renders the display name', () => {
+      render(<SummaryCard card={baseCard} />);
+
+      expect(screen.getByText('Cash on Hand')).toBeInTheDocument();
+    });
+
+    it('renders the formatted currency value', () => {
+      render(<SummaryCard card={baseCard} />);
+
+      expect(screen.getByTestId('summary-card-value')).toBeInTheDocument();
+      expect(screen.getByTestId('summary-card-value').textContent).toContain('250');
+    });
+  });
+
+  describe('given a card with a months unit', () => {
+    it('renders the unit label as "months"', () => {
+      render(<SummaryCard card={runwayCard} />);
+
+      expect(screen.getByTestId('summary-card-unit')).toBeInTheDocument();
+      expect(screen.getByTestId('summary-card-unit').textContent).toContain('months');
+    });
+  });
+
+  describe('given a card with a positive delta', () => {
+    it('renders an up-arrow indicator', () => {
+      render(<SummaryCard card={cardWithPositiveDelta} />);
+
+      expect(screen.getByTestId('delta-up')).toBeInTheDocument();
+    });
+
+    it('applies green color styling to the delta', () => {
+      render(<SummaryCard card={cardWithPositiveDelta} />);
+
+      const delta = screen.getByTestId('delta-up');
+      expect(delta).toHaveClass('text-green-600');
+    });
+
+    it('renders the percent delta value', () => {
+      render(<SummaryCard card={cardWithPositiveDelta} />);
+
+      expect(screen.getByTestId('delta-percent')).toBeInTheDocument();
+      expect(screen.getByTestId('delta-percent').textContent).toContain('6.38');
+    });
+  });
+
+  describe('given a card with a negative delta', () => {
+    it('renders a down-arrow indicator', () => {
+      render(<SummaryCard card={cardWithNegativeDelta} />);
+
+      expect(screen.getByTestId('delta-down')).toBeInTheDocument();
+    });
+
+    it('applies red color styling to the delta', () => {
+      render(<SummaryCard card={cardWithNegativeDelta} />);
+
+      const delta = screen.getByTestId('delta-down');
+      expect(delta).toHaveClass('text-red-600');
+    });
+
+    it('renders the negative percent delta value', () => {
+      render(<SummaryCard card={cardWithNegativeDelta} />);
+
+      expect(screen.getByTestId('delta-percent').textContent).toContain('0.8');
+    });
+  });
+
+  describe('given a card with zero delta', () => {
+    it('does not render a directional arrow', () => {
+      render(<SummaryCard card={cardWithZeroDelta} />);
+
+      expect(screen.queryByTestId('delta-up')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('delta-down')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given a card without a delta', () => {
+    it('does not render any delta indicator', () => {
+      render(<SummaryCard card={baseCard} />);
+
+      expect(screen.queryByTestId('delta-up')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('delta-down')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('delta-percent')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('given a loading state', () => {
+    it('renders a loading skeleton when isLoading is true', () => {
+      render(<SummaryCard card={baseCard} isLoading={true} />);
+
+      expect(screen.getByTestId('summary-card-loading')).toBeInTheDocument();
+    });
+
+    it('does not render value content while loading', () => {
+      render(<SummaryCard card={baseCard} isLoading={true} />);
+
+      expect(screen.queryByTestId('summary-card-value')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/components/kpi-cards/SummaryCard.tsx
+++ b/components/kpi-cards/SummaryCard.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { SummaryCard as SummaryCardData } from '@/types/summary';
+
+interface SummaryCardProps {
+  card: SummaryCardData;
+  isLoading?: boolean;
+}
+
+function formatValue(value: number, unit: string): string {
+  if (unit === 'currency') {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+  return String(value);
+}
+
+export function SummaryCard({ card, isLoading }: SummaryCardProps) {
+  if (isLoading) {
+    return (
+      <div data-testid="summary-card-loading" aria-busy="true">
+        <div className="animate-pulse bg-gray-200 h-4 w-32 rounded mb-2" />
+        <div className="animate-pulse bg-gray-200 h-8 w-24 rounded" />
+      </div>
+    );
+  }
+
+  const { displayName, value, unit, delta } = card;
+
+  let deltaElement: React.ReactNode = null;
+
+  if (delta) {
+    const isPositive = delta.absoluteDelta > 0;
+    const isNegative = delta.absoluteDelta < 0;
+    const absPercent = delta.percentDelta !== null ? Math.abs(delta.percentDelta) : null;
+
+    if (isPositive) {
+      deltaElement = (
+        <span data-testid="delta-up" className="text-green-600 flex items-center gap-1 text-sm">
+          <span aria-hidden="true">&#x2191;</span>
+          {absPercent !== null && (
+            <span data-testid="delta-percent">{absPercent}%</span>
+          )}
+        </span>
+      );
+    } else if (isNegative) {
+      deltaElement = (
+        <span data-testid="delta-down" className="text-red-600 flex items-center gap-1 text-sm">
+          <span aria-hidden="true">&#x2193;</span>
+          {absPercent !== null && (
+            <span data-testid="delta-percent">{absPercent}%</span>
+          )}
+        </span>
+      );
+    }
+  }
+
+  return (
+    <div data-testid="summary-card">
+      <p className="text-sm text-gray-500">{displayName}</p>
+      <p data-testid="summary-card-value" className="text-2xl font-bold">
+        {formatValue(value, unit)}
+      </p>
+      <p data-testid="summary-card-unit" className="text-xs text-gray-400">
+        {unit}
+      </p>
+      {deltaElement}
+    </div>
+  );
+}

--- a/lib/kpi/summary.test.ts
+++ b/lib/kpi/summary.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchSummaryCards } from './summary';
+import type { ZeroDBClient } from '@/lib/zerodb/client';
+import {
+  mockSummaryMetricRows,
+  mockOtherOrgMetricRows,
+  mockComparisonRows,
+} from '@/__tests__/fixtures/summary';
+
+function createMockClient(overrides?: {
+  metricRows?: typeof mockSummaryMetricRows;
+  comparisonRows?: typeof mockComparisonRows;
+}): ZeroDBClient {
+  const metricRows = overrides?.metricRows ?? mockSummaryMetricRows;
+  const comparisonRows = overrides?.comparisonRows ?? mockComparisonRows;
+
+  return {
+    query: vi.fn(async (table: string, filters: Record<string, unknown>) => {
+      if (table === 'fact_financial_metrics') {
+        const orgId = filters.organization_id;
+        const metricNames = filters.metric_name as string[] | undefined;
+        let rows = metricRows.filter((r) => r.organization_id === orgId);
+        if (metricNames) {
+          rows = rows.filter((r) => metricNames.includes(r.metric_name));
+        }
+        return { rows };
+      }
+      if (table === 'fact_kpi_comparisons') {
+        const orgId = filters.organization_id;
+        const metricNames = filters.metric_name as string[] | undefined;
+        let rows = comparisonRows.filter((r) => r.organization_id === orgId);
+        if (metricNames) {
+          rows = rows.filter((r) => metricNames.includes(r.metric_name));
+        }
+        return { rows };
+      }
+      return { rows: [] };
+    }),
+  };
+}
+
+describe('fetchSummaryCards', () => {
+  describe('given metric data exists for the requested metrics', () => {
+    it('returns a SummaryCard for each requested metric', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand', 'runway_months'],
+      });
+
+      expect(result).toHaveLength(2);
+      const names = result.map((c) => c.metricName);
+      expect(names).toContain('cash_on_hand');
+      expect(names).toContain('runway_months');
+    });
+
+    it('populates value and unit from fact_financial_metrics', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand'],
+      });
+
+      expect(result[0].value).toBe(250000);
+      expect(result[0].unit).toBe('currency');
+    });
+
+    it('sets a human-readable displayName', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['runway_months'],
+      });
+
+      expect(result[0].displayName).toBe('Runway');
+    });
+  });
+
+  describe('given comparison data exists', () => {
+    it('attaches delta info to the card when includeComparison is true', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand'],
+        includeComparison: true,
+      });
+
+      expect(result[0].delta).toBeDefined();
+      expect(result[0].delta?.absoluteDelta).toBe(15000);
+      expect(result[0].delta?.percentDelta).toBe(6.38);
+      expect(result[0].delta?.comparisonType).toBe('prior_period');
+    });
+
+    it('omits delta when includeComparison is false', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand'],
+        includeComparison: false,
+      });
+
+      expect(result[0].delta).toBeUndefined();
+    });
+
+    it('omits delta when includeComparison is not provided', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand'],
+      });
+
+      expect(result[0].delta).toBeUndefined();
+    });
+  });
+
+  describe('given no comparison data exists for a metric', () => {
+    it('returns the card without a delta field', async () => {
+      const client = createMockClient({ comparisonRows: [] });
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['net_cash_flow'],
+        includeComparison: true,
+      });
+
+      expect(result[0].delta).toBeUndefined();
+    });
+  });
+
+  describe('given no metric data exists', () => {
+    it('returns an empty array', async () => {
+      const client = createMockClient({ metricRows: [] });
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand'],
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('given data for multiple organizations', () => {
+    it('only returns cards for the specified organizationId', async () => {
+      const allRows = [...mockSummaryMetricRows, ...mockOtherOrgMetricRows];
+      const client = createMockClient({ metricRows: allRows });
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['cash_on_hand'],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toBe(250000);
+    });
+  });
+
+  describe('given metrics with negative delta', () => {
+    it('preserves negative absoluteDelta on the card', async () => {
+      const client = createMockClient();
+
+      const result = await fetchSummaryCards(client, {
+        organizationId: 'org-1',
+        metricNames: ['runway_months'],
+        includeComparison: true,
+      });
+
+      expect(result[0].delta?.absoluteDelta).toBe(-2);
+      expect(result[0].delta?.percentDelta).toBe(-12.5);
+    });
+  });
+});

--- a/lib/kpi/summary.ts
+++ b/lib/kpi/summary.ts
@@ -1,0 +1,104 @@
+import type { ZeroDBClient } from '@/lib/zerodb/client';
+import type { SummaryApiRequest, SummaryCard } from '@/types/summary';
+
+interface FinancialMetricRow {
+  id: string;
+  organization_id: string;
+  period_id: string;
+  metric_name: string;
+  metric_value: number;
+  metric_unit: string;
+}
+
+interface KpiComparisonRow {
+  id: string;
+  organization_id: string;
+  metric_name: string;
+  current_period_id: string;
+  comparison_period_id: string;
+  current_value: number;
+  comparison_value: number;
+  absolute_delta: number;
+  percent_delta: number | null;
+  comparison_type: string;
+}
+
+const DISPLAY_NAMES: Record<string, string> = {
+  net_cash_flow: 'Net Cash Flow',
+  cash_on_hand: 'Cash on Hand',
+  cash_inflow: 'Cash Inflow',
+  cash_outflow: 'Cash Outflow',
+  runway_months: 'Runway',
+  ar_balance: 'AR Balance',
+  ap_balance: 'AP Balance',
+  total_revenue: 'Total Revenue',
+  net_profit: 'Net Profit',
+  gross_profit: 'Gross Profit',
+  total_expenses: 'Total Expenses',
+  burn_rate: 'Burn Rate',
+};
+
+function toDisplayName(metricName: string): string {
+  return (
+    DISPLAY_NAMES[metricName] ??
+    metricName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}
+
+export async function fetchSummaryCards(
+  client: ZeroDBClient,
+  request: SummaryApiRequest
+): Promise<SummaryCard[]> {
+  const { organizationId, metricNames, includeComparison } = request;
+
+  const metricResult = await client.query<FinancialMetricRow>('fact_financial_metrics', {
+    organization_id: organizationId,
+    metric_name: metricNames,
+  });
+
+  if (metricResult.rows.length === 0) {
+    return [];
+  }
+
+  let comparisonMap = new Map<string, KpiComparisonRow>();
+
+  if (includeComparison) {
+    const comparisonResult = await client.query<KpiComparisonRow>('fact_kpi_comparisons', {
+      organization_id: organizationId,
+      metric_name: metricNames,
+    });
+    for (const row of comparisonResult.rows) {
+      comparisonMap.set(row.metric_name, row);
+    }
+  }
+
+  // Build a map of latest metric value per metric name
+  const metricMap = new Map<string, FinancialMetricRow>();
+  for (const row of metricResult.rows) {
+    metricMap.set(row.metric_name, row);
+  }
+
+  return metricNames
+    .filter((name) => metricMap.has(name))
+    .map((name): SummaryCard => {
+      const metric = metricMap.get(name)!;
+      const comparison = comparisonMap.get(name);
+
+      const card: SummaryCard = {
+        metricName: name,
+        displayName: toDisplayName(name),
+        value: metric.metric_value,
+        unit: metric.metric_unit,
+      };
+
+      if (comparison) {
+        card.delta = {
+          absoluteDelta: comparison.absolute_delta,
+          percentDelta: comparison.percent_delta,
+          comparisonType: comparison.comparison_type,
+        };
+      }
+
+      return card;
+    });
+}

--- a/types/summary.ts
+++ b/types/summary.ts
@@ -1,0 +1,24 @@
+export interface SummaryCard {
+  metricName: string;
+  displayName: string;
+  value: number;
+  unit: string;
+  delta?: {
+    absoluteDelta: number;
+    percentDelta: number | null;
+    comparisonType: string;
+  };
+}
+
+export interface SummaryApiResponse {
+  cards: SummaryCard[];
+  organizationId: string;
+  periodType: string;
+}
+
+export interface SummaryApiRequest {
+  organizationId: string;
+  metricNames: string[];
+  periodType?: string;
+  includeComparison?: boolean;
+}


### PR DESCRIPTION
## Summary
- Net cash flow trend chart (inflow, outflow, net)
- Cash on hand and runway_months summary cards
- GET /api/kpis/summary endpoint with comparison support
- Reusable SummaryCard component

## Test Plan
- 37 BDD-style tests
- `npm test` passes all tests

Closes #18, Closes #19

Built by AINative Dev Team