### PR TITLE
feat: AR/AP balance summary cards

### DIFF
--- a/app/ar-ap/page.test.tsx
+++ b/app/ar-ap/page.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import ArApPage from './page';
+
+const validSummaryResponse = {
+  cards: [
+    {
+      metricName: 'ar_balance',
+      displayName: 'AR Balance',
+      value: 87500,
+      unit: 'currency',
+      delta: { absoluteDelta: -5000, percentDelta: -5.41, comparisonType: 'prior_period' },
+    },
+    {
+      metricName: 'ap_balance',
+      displayName: 'AP Balance',
+      value: 43200,
+      unit: 'currency',
+      delta: { absoluteDelta: 3200, percentDelta: 8.0, comparisonType: 'prior_period' },
+    },
+  ],
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+const emptySummaryResponse = {
+  cards: [],
+  organizationId: 'org-1',
+  periodType: 'monthly',
+};
+
+describe('AR/AP Page', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('given data loads successfully', () => {
+    it('renders the AR/AP page heading', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => validSummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      const heading = await screen.findByRole('heading', { name: /accounts receivable/i });
+      expect(heading).toBeInTheDocument();
+    });
+
+    it('renders the AR Balance summary card', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => validSummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      expect(await screen.findByText('AR Balance')).toBeInTheDocument();
+    });
+
+    it('renders the AP Balance summary card', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => validSummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      expect(await screen.findByText('AP Balance')).toBeInTheDocument();
+    });
+
+    it('renders the summary cards section', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => validSummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      expect(await screen.findByTestId('arap-summary-section')).toBeInTheDocument();
+    });
+
+    it('renders AR Balance card with a link to the aging table', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => validSummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      await screen.findByTestId('arap-summary-section');
+      const arLinks = screen.getAllByRole('link', { name: /ar balance/i });
+      expect(arLinks.length).toBeGreaterThan(0);
+      expect(arLinks[0]).toHaveAttribute('href', expect.stringContaining('ar'));
+    });
+
+    it('renders AP Balance card with a link to the aging table', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => validSummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      await screen.findByTestId('arap-summary-section');
+      const apLinks = screen.getAllByRole('link', { name: /ap balance/i });
+      expect(apLinks.length).toBeGreaterThan(0);
+      expect(apLinks[0]).toHaveAttribute('href', expect.stringContaining('ap'));
+    });
+  });
+
+  describe('given data is still loading', () => {
+    it('shows a loading indicator', () => {
+      mockFetch.mockReturnValue(new Promise(() => {}));
+
+      render(<ArApPage />);
+
+      expect(screen.getByTestId('arap-loading')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the API returns an error', () => {
+    it('shows an error state', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      render(<ArApPage />);
+
+      expect(await screen.findByTestId('arap-error')).toBeInTheDocument();
+    });
+  });
+
+  describe('given the API returns an empty cards array', () => {
+    it('renders a fallback empty state', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => emptySummaryResponse,
+      });
+
+      render(<ArApPage />);
+
+      expect(await screen.findByTestId('arap-summary-empty')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/ar-ap/page.tsx
+++ b/app/ar-ap/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SummaryCard } from '@/components/kpi-cards/SummaryCard';
+import type { SummaryCard as SummaryCardData } from '@/types/summary';
+
+type LoadState = 'loading' | 'loaded' | 'error';
+
+const ORG_ID = 'org-1';
+const SUMMARY_METRICS = 'ar_balance,ap_balance';
+
+const AGING_LINKS: Record<string, string> = {
+  ar_balance: '/ar-ap/ar-aging',
+  ap_balance: '/ar-ap/ap-aging',
+};
+
+export default function ArApPage() {
+  const [cards, setCards] = useState<SummaryCardData[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+
+  useEffect(() => {
+    const summaryUrl = `/api/kpis/summary?organizationId=${ORG_ID}&metrics=${SUMMARY_METRICS}&periodType=monthly&includeComparison=true`;
+
+    fetch(summaryUrl)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        setCards(data.cards);
+        setLoadState('loaded');
+      })
+      .catch(() => {
+        setLoadState('error');
+      });
+  }, []);
+
+  return (
+    <div>
+      <h1>Accounts Receivable &amp; Payable</h1>
+
+      {loadState === 'loading' && (
+        <div data-testid="arap-loading">
+          <p>Loading AR/AP data...</p>
+        </div>
+      )}
+
+      {loadState === 'error' && (
+        <div data-testid="arap-error">
+          <p>Failed to load AR/AP data. Please try again.</p>
+        </div>
+      )}
+
+      {loadState === 'loaded' && (
+        <section data-testid="arap-summary-section">
+          <h2>Balance Summary</h2>
+          {cards.length === 0 ? (
+            <div data-testid="arap-summary-empty">
+              <p>No balance data available.</p>
+            </div>
+          ) : (
+            <div>
+              {cards.map((card) => {
+                const href = AGING_LINKS[card.metricName] ?? '#';
+                return (
+                  <div key={card.metricName}>
+                    <a href={href} aria-label={card.displayName}>
+                      <SummaryCard card={card} />
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- AR/AP balance summary cards with delta indicators
- Cards link to aging table placeholders
- Comparison values from fact_kpi_comparisons

## Test Plan
- 8 BDD-style tests
- `npm test` passes all tests

Closes #20

Built by AINative Dev Team